### PR TITLE
WIP.

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockHandler.java
@@ -198,10 +198,6 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
     private final Timer registerExecutorRequestLatencyMillis = new Timer();
     // Block transfer rate in byte per second
     private final Meter blockTransferRateBytes = new Meter();
-    // Partition upload latency in ms
-    private final Timer uploadPartitionkStreamMillis = new Timer();
-    // Partition read latency in ms
-    private final Timer openPartitionMillis = new Timer();
 
     private ShuffleMetrics() {
       allMetrics = new HashMap<>();
@@ -210,8 +206,6 @@ public class ExternalShuffleBlockHandler extends RpcHandler {
       allMetrics.put("blockTransferRateBytes", blockTransferRateBytes);
       allMetrics.put("registeredExecutorsSize",
                      (Gauge<Integer>) () -> blockManager.getRegisteredExecutorsSize());
-      allMetrics.put("uploadPartitionkStreamMillis", uploadPartitionkStreamMillis);
-      allMetrics.put("openPartitionMillis", openPartitionMillis);
     }
 
     @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -19,7 +19,6 @@ package org.apache.spark.network.shuffle;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.regex.Pattern;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
@@ -94,7 +93,7 @@ public class ExternalShuffleBlockResolver {
 
   private final List<String> knownManagers = Arrays.asList(
     "org.apache.spark.shuffle.sort.SortShuffleManager",
-     "org.apache.spark.shuffle.unsafe.UnsafeShuffleManager");
+    "org.apache.spark.shuffle.unsafe.UnsafeShuffleManager");
 
   public ExternalShuffleBlockResolver(TransportConf conf, File registeredExecutorFile)
       throws IOException {
@@ -132,7 +131,6 @@ public class ExternalShuffleBlockResolver {
     } else {
       executors = Maps.newConcurrentMap();
     }
-
     this.directoryCleaner = directoryCleaner;
   }
 
@@ -180,8 +178,6 @@ public class ExternalShuffleBlockResolver {
     }
     return getSortBasedShuffleBlockData(executor, shuffleId, mapId, reduceId);
   }
-
-
 
   /**
    * Removes our metadata of all executors registered for the given application, and optionally

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDataIO.java
@@ -16,11 +16,13 @@
  */
 package org.apache.spark.shuffle.api;
 
+import java.io.IOException;
+
 public interface ShuffleDataIO {
 
-  void initialize();
+  void initialize() throws IOException;
 
-  ShuffleReadSupport readSupport();
+  ShuffleReadSupport readSupport() throws IOException;
 
-  ShuffleWriteSupport writeSupport();
+  ShuffleWriteSupport writeSupport() throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDataIO.java
@@ -25,4 +25,6 @@ public interface ShuffleDataIO {
   ShuffleReadSupport readSupport() throws IOException;
 
   ShuffleWriteSupport writeSupport() throws IOException;
+
+  void shuffleCleaned(int shuffleId) throws Exception;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
@@ -17,11 +17,13 @@
 
 package org.apache.spark.shuffle.api;
 
+import java.io.IOException;
+
 public interface ShuffleMapOutputWriter {
 
-  ShufflePartitionWriter newPartitionWriter(int partitionId);
+  ShufflePartitionWriter newPartitionWriter(int partitionId) throws IOException;
 
-  void commitAllPartitions();
+  void commitAllPartitions() throws IOException;
 
-  void abort(Exception exception);
+  void abort(Exception exception) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionReader.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionReader.java
@@ -17,12 +17,14 @@
 
 package org.apache.spark.shuffle.api;
 
-import org.apache.spark.storage.ShuffleLocation;
-
 import java.io.InputStream;
+import java.io.IOException;
 import java.util.Optional;
+
+import org.apache.spark.storage.ShuffleLocation;
 
 public interface ShufflePartitionReader {
 
-  InputStream fetchPartition(int reduceId, Optional<ShuffleLocation> shuffleLocation);
+  InputStream fetchPartition(int reduceId, Optional<ShuffleLocation> shuffleLocation)
+     throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionReader.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionReader.java
@@ -17,9 +17,12 @@
 
 package org.apache.spark.shuffle.api;
 
+import org.apache.spark.storage.ShuffleLocation;
+
 import java.io.InputStream;
+import java.util.Optional;
 
 public interface ShufflePartitionReader {
 
-  InputStream fetchPartition(int reduceId);
+  InputStream fetchPartition(int reduceId, Optional<ShuffleLocation> shuffleLocation);
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.api;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -27,18 +28,18 @@ public interface ShufflePartitionWriter {
   /**
    * Return a stream that should persist the bytes for this partition.
    */
-  OutputStream openPartitionStream();
+  OutputStream openPartitionStream() throws IOException;
 
   /**
    * Indicate that the partition was written successfully and there are no more incoming bytes.
    * Returns a {@link CommittedPartition} indicating information about that written partition.
    */
-  CommittedPartition commitPartition();
+  CommittedPartition commitPartition() throws IOException;
 
   /**
    * Indicate that the write has failed for some reason and the implementation can handle the
    * failure reason. After this method is called, this writer will be discarded; it's expected that
    * the implementation will close any underlying resources.
    */
-  void abort(Exception failureReason);
+  void abort(Exception failureReason) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleReadSupport.java
@@ -17,8 +17,11 @@
 
 package org.apache.spark.shuffle.api;
 
+import java.io.IOException;
+
 public interface ShuffleReadSupport {
 
-  ShufflePartitionReader newPartitionReader(String appId, int shuffleId, int mapId);
+  ShufflePartitionReader newPartitionReader(String appId, int shuffleId, int mapId)
+    throws IOException;
 
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleWriteSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleWriteSupport.java
@@ -17,7 +17,10 @@
 
 package org.apache.spark.shuffle.api;
 
+import java.io.IOException;
+
 public interface ShuffleWriteSupport {
 
-  ShuffleMapOutputWriter newMapOutputWriter(String appId, int shuffleId, int mapId);
+  ShuffleMapOutputWriter newMapOutputWriter(String appId, int shuffleId, int mapId)
+     throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleDataIO.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.dfs;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import scala.Option;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.deploy.SparkHadoopUtil;
+import org.apache.spark.internal.config.Shuffle;
+import org.apache.spark.shuffle.api.ShuffleDataIO;
+import org.apache.spark.shuffle.api.ShuffleReadSupport;
+import org.apache.spark.shuffle.api.ShuffleWriteSupport;
+
+public class DFSShuffleDataIO implements ShuffleDataIO {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DFSShuffleDataIO.class);
+
+  private Configuration conf;
+  private FileSystem fs;
+  private Path path;
+
+  public DFSShuffleDataIO(SparkConf sparkConf) throws IOException {
+    // If DFS_IO_PATH is not set, assume we're in the driver, and initialize it. This needs to
+    // be done before initialize() so that it's set before any executors are alive.
+    Option<String> pathOption = sparkConf.get(Shuffle.DFS_IO_PATH());
+    if (pathOption.isEmpty()) {
+      // TODO: The base path currently needs to be defined by the user. In YARN it should probably
+      // be based on the staging dir unless configured otherwise.
+      Option<String> basePathOption = sparkConf.get(Shuffle.DFS_IO_BASE_PATH());
+      Preconditions.checkArgument(basePathOption.isDefined(),
+        "Missing %s configuration.", Shuffle.DFS_IO_BASE_PATH().key());
+
+      Path basePath = new Path(basePathOption.get());
+
+      // TODO: this configuration should come from the driver somehow.
+      Configuration conf = SparkHadoopUtil.get().newConfiguration(sparkConf);
+      FileSystem fs = basePath.getFileSystem(conf);
+
+      Path path;
+      do {
+        path = new Path(basePath, UUID.randomUUID().toString());
+      } while (fs.exists(path));
+
+      if (!fs.mkdirs(path)) {
+        throw new IOException("Failed to create shuffle directory " + path);
+      }
+
+      sparkConf.set(Shuffle.DFS_IO_PATH(), path.toString());
+      LOG.info("Shuffle data will be written to {}.", path.toString());
+    }
+  }
+
+  @Override
+  public void initialize() throws IOException {
+    SparkConf sparkConf = SparkEnv.get().conf();
+    Option<String> pathOption = sparkConf.get(Shuffle.DFS_IO_PATH());
+    Preconditions.checkState(pathOption.isDefined(), "Shuffle directory has not been configured.");
+
+    this.path = new Path(pathOption.get());
+
+    // TODO: this configuration should come from the driver somehow.
+    this.conf = SparkHadoopUtil.get().newConfiguration(sparkConf);
+    this.fs = path.getFileSystem(conf);
+  }
+
+  @Override
+  public ShuffleReadSupport readSupport() {
+    return new DFSShuffleReadSupport(fs, path);
+  }
+
+  @Override
+  public ShuffleWriteSupport writeSupport() throws IOException {
+    return new DFSShuffleWriteSupport(conf, fs, path);
+  }
+
+  @Override
+  public void shuffleCleaned(int shuffleId) throws Exception {
+    Path shufflePath = new Path(path, String.format("shuffle-%d", shuffleId));
+    fs.delete(shufflePath, true);
+  }
+
+  private static FileSystem getFileSystem(SparkConf sparkConf, Path path) throws IOException {
+    // TODO: this configuration should come from the driver somehow.
+    Configuration conf = SparkHadoopUtil.get().newConfiguration(sparkConf);
+    return path.getFileSystem(conf);
+  }
+
+}

--- a/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleReadSupport.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.dfs;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.spark.shuffle.api.ShuffleReadSupport;
+import org.apache.spark.shuffle.api.ShufflePartitionReader;
+import org.apache.spark.storage.ShuffleLocation;
+
+class DFSShuffleReadSupport implements ShuffleReadSupport {
+
+  private final FileSystem fs;
+  private final Path path;
+
+  DFSShuffleReadSupport(FileSystem fs, Path path) {
+    this.fs = fs;
+    this.path = path;
+  }
+
+  @Override
+  public ShufflePartitionReader newPartitionReader(String appId, int shuffleId, int mapId) {
+    return new PartitionReader(shuffleId, mapId);
+  }
+
+  private class PartitionReader implements ShufflePartitionReader {
+
+    private final int shuffleId;
+    private final int mapId;
+
+    PartitionReader(int shuffleId, int mapId) {
+      this.shuffleId = shuffleId;
+      this.mapId = mapId;
+    }
+
+    @Override
+    public InputStream fetchPartition(int reduceId, Optional<ShuffleLocation> location)
+        throws IOException {
+      String shuffleFile = String.format("shuffle-%d/%d/%d", shuffleId, reduceId, mapId);
+      Path shufflePath = new Path(path, shuffleFile);
+      return fs.open(shufflePath);
+    }
+
+  }
+
+}

--- a/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleWriteSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/dfs/DFSShuffleWriteSupport.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.dfs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.EnumSet;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.apache.spark.TaskContext;
+import org.apache.spark.shuffle.api.CommittedPartition;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+import org.apache.spark.shuffle.api.ShuffleWriteSupport;
+import org.apache.spark.storage.ShuffleLocation;
+
+class DFSShuffleWriteSupport implements ShuffleWriteSupport {
+
+  private final FileContext fc;
+  private final FileSystem fs;
+  private final Path path;
+
+  DFSShuffleWriteSupport(Configuration conf, FileSystem fs, Path path) throws IOException {
+    this.fs = fs;
+    this.fc = FileContext.getFileContext(path.toUri(), conf);
+    this.path = path;
+  }
+
+  @Override
+  public ShuffleMapOutputWriter newMapOutputWriter(String appId, int shuffleId, int mapId) {
+    return new MapOutputWriter(shuffleId, mapId);
+  }
+
+  private class MapOutputWriter implements ShuffleMapOutputWriter {
+
+    private final int shuffleId;
+    private final int mapId;
+
+    MapOutputWriter(int shuffleId, int mapId) {
+      this.shuffleId = shuffleId;
+      this.mapId = mapId;
+    }
+
+    @Override
+    public ShufflePartitionWriter newPartitionWriter(int partitionId) throws IOException {
+      String shuffleOutput = String.format("shuffle-%d/%d/%d", shuffleId, partitionId, mapId);
+      return new PartitionWriter(new Path(path, shuffleOutput));
+    }
+
+    @Override
+    public void commitAllPartitions() {
+      // Nothing to do. Handled by the partition writers.
+    }
+
+    @Override
+    public void abort(Exception exception) {
+      // Nothing to do. Handled by the partition writers.
+    }
+
+  }
+
+  private class PartitionWriter implements ShufflePartitionWriter {
+
+    private final Path output;
+    private CountingOutputStream stream;
+
+    PartitionWriter(Path output) {
+      this.output = output;
+    }
+
+    @Override
+    public OutputStream openPartitionStream() throws IOException {
+      stream = new CountingOutputStream(fs.create(getTempPath()));
+      return stream;
+    }
+
+    @Override
+    public CommittedPartition commitPartition() throws IOException {
+      Preconditions.checkState(stream != null);
+      stream.close();
+
+      Path tmp = getTempPath();
+      try {
+        fc.rename(tmp, output);
+
+        final long length = stream.getByteCount();
+        return new CommittedPartition() {
+          @Override
+          public long length() {
+            return length;
+          }
+
+          @Override
+          public Optional<ShuffleLocation> shuffleLocation() {
+            return Optional.empty();
+          }
+        };
+      } catch (FileAlreadyExistsException faee) {
+        // Another speculative task won the race, so just ignore this output.
+        fs.delete(tmp, true);
+        return null;
+      }
+    }
+
+    @Override
+    public void abort(Exception failureReason) throws IOException {
+      if (stream != null) {
+        stream.close();
+        fs.delete(getTempPath(), true);
+      }
+    }
+
+    private Path getTempPath() {
+      TaskContext tc = TaskContext.get();
+      Path tmp = new Path(output.toString() + ".tmp." + tc.taskAttemptId());
+      System.out.printf("tmp = %s, out = %s\n", tmp, output);
+      return tmp;
+    }
+
+  }
+
+}

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
@@ -21,7 +21,6 @@ public class ExternalShuffleDataIO implements ShuffleDataIO {
     private static SecurityManager securityManager;
     private static String hostname;
     private static int port;
-    private static MapOutputTracker mapOutputTracker;
 
     public ExternalShuffleDataIO(
             SparkConf sparkConf) {
@@ -37,15 +36,13 @@ public class ExternalShuffleDataIO implements ShuffleDataIO {
         securityManager = env.securityManager();
         hostname = blockManager.getRandomShuffleHost();
         port = blockManager.getRandomShufflePort();
-        mapOutputTracker = env.mapOutputTracker();
         // TODO: Register Driver and Executor
     }
 
     @Override
     public ShuffleReadSupport readSupport() {
         return new ExternalShuffleReadSupport(
-                conf, context, securityManager.isAuthenticationEnabled(),
-                securityManager, mapOutputTracker);
+                conf, context, securityManager.isAuthenticationEnabled(), securityManager);
     }
 
     @Override

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
@@ -1,8 +1,8 @@
 package org.apache.spark.shuffle.external;
 
-import org.apache.spark.MapOutputTracker;
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkEnv;
+import org.apache.spark.*;
+import org.apache.spark.SecurityManager;
+import org.apache.spark.internal.config.package$;
 import org.apache.spark.network.TransportContext;
 import org.apache.spark.network.netty.SparkTransportConf;
 import org.apache.spark.network.server.NoOpRpcHandler;
@@ -10,45 +10,77 @@ import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.shuffle.api.ShuffleDataIO;
 import org.apache.spark.shuffle.api.ShuffleReadSupport;
 import org.apache.spark.shuffle.api.ShuffleWriteSupport;
-import org.apache.spark.SecurityManager;
+import org.apache.spark.network.shuffle.k8s.KubernetesExternalShuffleClient;
+
 import org.apache.spark.storage.BlockManager;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.Random;
 
 public class ExternalShuffleDataIO implements ShuffleDataIO {
 
-    private final TransportConf conf;
+    private final SparkConf conf;
+    private final TransportConf transportConf;
     private final TransportContext context;
-    private static BlockManager blockManager;
+    private static MapOutputTracker mapOutputTracker;
     private static SecurityManager securityManager;
-    private static String hostname;
-    private static int port;
+    private static List<Tuple2<String, Integer>> hostPorts;
+    private static Boolean isDriver;
+    private static KubernetesExternalShuffleClient shuffleClient;
 
     public ExternalShuffleDataIO(
             SparkConf sparkConf) {
-        this.conf = SparkTransportConf.fromSparkConf(sparkConf, "shuffle", 1);
+        this.conf = sparkConf;
+        // TODO: Grab numUsableCores
+        this.transportConf = SparkTransportConf.fromSparkConf(sparkConf, "shuffle", 1);
         // Close idle connections
-        this.context = new TransportContext(conf, new NoOpRpcHandler(), true, true);
+        this.context = new TransportContext(transportConf, new NoOpRpcHandler(), true, true);
     }
 
     @Override
     public void initialize() {
         SparkEnv env = SparkEnv.get();
-        blockManager = env.blockManager();
+        mapOutputTracker = env.mapOutputTracker();
         securityManager = env.securityManager();
-        hostname = blockManager.getRandomShuffleHost();
-        port = blockManager.getRandomShufflePort();
-        // TODO: Register Driver and Executor
+        isDriver = env.blockManager().blockManagerId().isDriver();
+        hostPorts = mapOutputTracker.getRemoteShuffleServiceAddress();
+        if (isDriver) {
+            shuffleClient = new KubernetesExternalShuffleClient(transportConf, securityManager,
+            securityManager.isAuthenticationEnabled(), conf.getTimeAsMs(
+                package$.MODULE$.SHUFFLE_REGISTRATION_TIMEOUT().key(), "5000ms"));
+            shuffleClient.init(conf.getAppId());
+            for (Tuple2<String, Integer> hp : hostPorts) {
+                try {
+                    shuffleClient.registerDriverWithShuffleService(
+                        hp._1, hp._2,
+                        conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
+                        conf.getTimeAsSeconds("spark.network.timeout", "120s") + "s"),
+                        conf.getTimeAsSeconds(
+                            package$.MODULE$.EXECUTOR_HEARTBEAT_INTERVAL().key(), "10s"));
+                } catch (Exception e) {
+                    throw new RuntimeException("Unable to register driver with ESS", e);
+                }
+            }
+            BlockManager.ShuffleMetricsSource metricSource =
+                new BlockManager.ShuffleMetricsSource(
+                    "RemoteShuffleService", shuffleClient.shuffleMetrics());
+            env.metricsSystem().registerSource(metricSource);
+        }
     }
 
     @Override
     public ShuffleReadSupport readSupport() {
         return new ExternalShuffleReadSupport(
-                conf, context, securityManager.isAuthenticationEnabled(), securityManager);
+            transportConf, context, securityManager.isAuthenticationEnabled(), securityManager);
     }
 
     @Override
     public ShuffleWriteSupport writeSupport() {
+        int rnd = new Random().nextInt(hostPorts.size());
+        Tuple2<String, Integer> hostPort = hostPorts.get(rnd);
         return new ExternalShuffleWriteSupport(
-            conf, context, securityManager.isAuthenticationEnabled(),
-            securityManager, hostname, port);
+            transportConf, context, securityManager.isAuthenticationEnabled(),
+            securityManager, hostPort._1, hostPort._2);
     }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleDataIO.java
@@ -83,4 +83,9 @@ public class ExternalShuffleDataIO implements ShuffleDataIO {
             transportConf, context, securityManager.isAuthenticationEnabled(),
             securityManager, hostPort._1, hostPort._2);
     }
+
+    @Override
+    public void shuffleCleaned(int shuffleId) throws Exception {
+      // TODO.
+    }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleLocation.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleLocation.java
@@ -1,7 +1,5 @@
 package org.apache.spark.shuffle.external;
 
-import org.apache.hadoop.mapreduce.task.reduce.Shuffle;
-import org.apache.spark.network.protocol.Encoders;
 import org.apache.spark.storage.ShuffleLocation;
 
 import java.io.*;

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShufflePartitionReader.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShufflePartitionReader.java
@@ -8,7 +8,6 @@ import org.apache.spark.storage.ShuffleLocation;
 import org.apache.spark.util.ByteBufferInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.compat.java8.OptionConverters;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -39,8 +38,10 @@ public class ExternalShufflePartitionReader implements ShufflePartitionReader {
 
     @Override
     public InputStream fetchPartition(int reduceId, Optional<ShuffleLocation> shuffleLocation) {
-        assert shuffleLocation.isPresent() && shuffleLocation.get() instanceof ExternalShuffleLocation;
-        ExternalShuffleLocation externalShuffleLocation = (ExternalShuffleLocation) shuffleLocation.get();
+        assert shuffleLocation.isPresent() &&
+               shuffleLocation.get() instanceof ExternalShuffleLocation;
+        ExternalShuffleLocation externalShuffleLocation =
+            (ExternalShuffleLocation) shuffleLocation.get();
         logger.info(String.format("Found external shuffle location on node: %s:%d",
                 externalShuffleLocation.getShuffleHostname(),
                 externalShuffleLocation.getShufflePort()));

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
@@ -1,5 +1,7 @@
 package org.apache.spark.shuffle.external;
 
+import scala.compat.java8.OptionConverters;
+
 import com.google.common.collect.Lists;
 import org.apache.spark.MapOutputTracker;
 import org.apache.spark.network.TransportContext;
@@ -13,7 +15,6 @@ import org.apache.spark.shuffle.api.ShuffleReadSupport;
 import org.apache.spark.storage.ShuffleLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.compat.java8.OptionConverters;
 
 import java.util.List;
 import java.util.Optional;

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
@@ -1,9 +1,6 @@
 package org.apache.spark.shuffle.external;
 
-import scala.compat.java8.OptionConverters;
-
 import com.google.common.collect.Lists;
-import org.apache.spark.MapOutputTracker;
 import org.apache.spark.network.TransportContext;
 import org.apache.spark.network.client.TransportClientBootstrap;
 import org.apache.spark.network.client.TransportClientFactory;
@@ -12,12 +9,10 @@ import org.apache.spark.network.sasl.SecretKeyHolder;
 import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.shuffle.api.ShufflePartitionReader;
 import org.apache.spark.shuffle.api.ShuffleReadSupport;
-import org.apache.spark.storage.ShuffleLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Optional;
 
 public class ExternalShuffleReadSupport implements ShuffleReadSupport {
 

--- a/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/external/ExternalShuffleReadSupport.java
@@ -1,5 +1,7 @@
 package org.apache.spark.shuffle.external;
 
+import scala.compat.java8.OptionConverters;
+
 import com.google.common.collect.Lists;
 import org.apache.spark.network.TransportContext;
 import org.apache.spark.network.client.TransportClientBootstrap;

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -46,7 +46,6 @@ import scala.collection.Iterator;
 import javax.annotation.Nullable;
 import java.io.*;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 /**
  * This class implements sort-based shuffle's hash-style shuffle fallback path. This write path
@@ -171,6 +170,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       try {
         committedPartitions = combineAndWritePartitions(tmp);
         logger.info("Successfully wrote partitions without shuffle");
+        // TODO: Investigate when commitedPartitions is null or returns empty
         shuffleBlockResolver.writeIndexFileAndCommit(shuffleId,
                 mapId,
                 Arrays.stream(committedPartitions).mapToLong(p -> p.length()).toArray(),
@@ -213,7 +213,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
           boolean copyThrewException = true;
           try {
             partitions[i] =
-                    new LocalCommittedPartition(Utils.copyStream(in, out, false, transferToEnabled));
+              new LocalCommittedPartition(Utils.copyStream(in, out, false, transferToEnabled));
             copyThrewException = false;
           } finally {
             Closeables.close(in, copyThrewException);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -23,10 +23,8 @@ import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.spark.shuffle.api.CommittedPartition;
-import org.apache.spark.storage.ShuffleLocation;
 import scala.Option;
 import scala.Product2;
 import scala.collection.JavaConverters;
@@ -339,14 +337,17 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
           // that doesn't need to interpret the spilled bytes.
           if (transferToEnabled && !encryptionEnabled) {
             logger.debug("Using transferTo-based fast merge");
-            committedPartitions = toLocalCommittedPartition(mergeSpillsWithTransferTo(spills, outputFile));
+            committedPartitions =
+              toLocalCommittedPartition(mergeSpillsWithTransferTo(spills, outputFile));
           } else {
             logger.debug("Using fileStream-based fast merge");
-            committedPartitions = toLocalCommittedPartition(mergeSpillsWithFileStream(spills, outputFile, null));
+            committedPartitions = toLocalCommittedPartition(
+              mergeSpillsWithFileStream(spills, outputFile, null));
           }
         } else {
           logger.debug("Using slow merge");
-          committedPartitions = toLocalCommittedPartition(mergeSpillsWithFileStream(spills, outputFile, compressionCodec));
+          committedPartitions = toLocalCommittedPartition(
+            mergeSpillsWithFileStream(spills, outputFile, compressionCodec));
         }
         // When closing an UnsafeShuffleExternalSorter that has already spilled once but also has
         // in-memory records, we write out the in-memory records to a file but do not count that

--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -225,6 +225,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
       mapOutputTrackerMaster.unregisterShuffle(shuffleId)
       blockManagerMaster.removeShuffle(shuffleId, blocking)
       listeners.asScala.foreach(_.shuffleCleaned(shuffleId))
+      shuffleIO.foreach(_.shuffleCleaned(shuffleId))
       logInfo("Cleaned shuffle " + shuffleId)
     } catch {
       case e: Exception => logError("Error cleaning shuffle " + shuffleId, e)
@@ -274,6 +275,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
   private def blockManagerMaster = sc.env.blockManager.master
   private def broadcastManager = sc.env.broadcastManager
   private def mapOutputTrackerMaster = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+  private def shuffleIO = sc.env.shuffleDataIO
 }
 
 private object ContextCleaner {

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -118,7 +118,7 @@ private[spark] class Executor(
     env.blockManager.initialize(conf.getAppId)
     env.metricsSystem.registerSource(executorSource)
     env.metricsSystem.registerSource(env.blockManager.shuffleMetricsSource)
-    // Initialize the ShuffleDataIo
+    // Initialize the ShuffleDataIO
     env.shuffleDataIO.foreach(_.initialize())
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/Shuffle.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Shuffle.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.config
+
+private[spark] object Shuffle {
+
+  val DFS_IO_PATH = ConfigBuilder("spark.shuffle.dfs.path")
+    .doc("Used internally to define where to write shuffle files.")
+    .internal()
+    .stringConf
+    .createOptional
+
+  val DFS_IO_BASE_PATH = ConfigBuilder("spark.shuffle.dfs.basePath")
+    .doc("Base path where to store shuffle files in the distributed fs.")
+    .stringConf
+    .createOptional
+
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -20,7 +20,7 @@ package org.apache.spark.shuffle
 import scala.compat.java8.OptionConverters
 
 import org.apache.spark._
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.shuffle.api.ShuffleReadSupport
 import org.apache.spark.storage._

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.shuffle
 
+import scala.compat.java8.OptionConverters
+
 import org.apache.spark._
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.{Logging, config}
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.shuffle.api.ShuffleReadSupport
 import org.apache.spark.storage._
@@ -54,10 +56,12 @@ private[spark] class BlockStoreShuffleReader[K, C](
           blockIds.map {
             case blockId@ShuffleBlockId(_, _, reduceId) =>
               (blockId, serializerManager.wrapStream(blockId,
-                reader.fetchPartition(reduceId)))
+                reader.fetchPartition(reduceId, OptionConverters.toJava(
+                  mapOutputTracker.getShuffleLocation(handle.shuffleId, mapId, reduceId)))))
             case dataBlockId@ShuffleDataBlockId(_, _, reduceId) =>
               (dataBlockId, serializerManager.wrapStream(dataBlockId,
-                reader.fetchPartition(reduceId)))
+                reader.fetchPartition(reduceId, OptionConverters.toJava(
+                  mapOutputTracker.getShuffleLocation(handle.shuffleId, mapId, reduceId)))))
             case invalid =>
               throw new IllegalArgumentException(s"Invalid block id $invalid")
           }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -71,7 +71,7 @@ private[spark] class SortShuffleWriter[K, V, C](
     try {
       val blockId = ShuffleBlockId(dep.shuffleId, mapId, IndexShuffleBlockResolver.NOOP_REDUCE_ID)
       val committedPartitions = pluggableWriteSupport.map { writeSupport =>
-        sorter.writePartitionedToExternalShuffleWriteSupport(mapId, dep.shuffleId, writeSupport)
+        sorter.writePartitionedToExternalShuffleWriteSupport(blockId, writeSupport)
       }.getOrElse(sorter.writePartitionedFile(blockId, tmp))
       if (pluggableWriteSupport.isEmpty) {
         shuffleBlockResolver.writeIndexFileAndCommit(dep.shuffleId,

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.storage
 
 import java.io._
-import java.lang.ref.{WeakReference, ReferenceQueue => JReferenceQueue}
+import java.lang.ref.{ReferenceQueue => JReferenceQueue, WeakReference}
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.util.Collections
@@ -31,11 +31,12 @@ import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.Random
 import scala.util.control.NonFatal
+
 import com.codahale.metrics.{MetricRegistry, MetricSet}
 
 import org.apache.spark._
 import org.apache.spark.executor.DataReadMethod
-import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.memory.{MemoryManager, MemoryMode}
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.network._

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -44,7 +44,6 @@ import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.client.StreamCallbackWithID
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle._
-import org.apache.spark.network.shuffle.k8s.KubernetesExternalShuffleClient
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo
 import org.apache.spark.network.util.TransportConf
 import org.apache.spark.rpc.RpcEnv
@@ -131,14 +130,8 @@ private[spark] class BlockManager(
     numUsableCores: Int)
   extends BlockDataManager with BlockEvictionHandler with Logging {
 
-  private[spark] val externalNonK8sShuffleService =
-    conf.get(config.SHUFFLE_SERVICE_ENABLED)
-
-  private[spark] val externalk8sShuffleServiceEnabled =
-    conf.get(config.K8S_SHUFFLE_SERVICE_ENABLED)
-
   private[spark] val externalShuffleServiceEnabled =
-    externalNonK8sShuffleService || externalk8sShuffleServiceEnabled
+    conf.get(config.SHUFFLE_SERVICE_ENABLED)
 
   private val remoteReadNioBufferConversion =
     conf.getBoolean("spark.network.remoteReadNioBufferConversion", false)
@@ -184,9 +177,6 @@ private[spark] class BlockManager(
     }
   }
 
-  private var remoteShuffleServiceAddress: List[(String, Int)] = List()
-  private var randomShuffleServiceAddress: (String, Int) = null
-
   var blockManagerId: BlockManagerId = _
 
   // Address of the server that serves this executor's shuffle files. This is either an external
@@ -195,11 +185,7 @@ private[spark] class BlockManager(
 
   // Client to read other executors' shuffle files. This is either an external service, or just the
   // standard BlockTransferService to directly connect to other Executors.
-  private[spark] val shuffleClient = if (externalk8sShuffleServiceEnabled) {
-    val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
-    new KubernetesExternalShuffleClient(transConf, securityManager,
-      securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
-  } else if (externalNonK8sShuffleService) {
+  private[spark] val shuffleClient = if (externalShuffleServiceEnabled) {
     val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
     new ExternalShuffleClient(transConf, securityManager,
       securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT))
@@ -267,35 +253,14 @@ private[spark] class BlockManager(
 
     blockManagerId = if (idFromMaster != null) idFromMaster else id
 
-    if (externalk8sShuffleServiceEnabled) {
-      remoteShuffleServiceAddress = mapOutputTracker
-        .trackerEndpoint
-        .askSync[List[(String, Int)]](GetRemoteShuffleServiceAddresses)
-    }
-
-    shuffleServerId = if (externalk8sShuffleServiceEnabled) {
-      // TODO: Investigate better methods of load balancing
-      // note: might break if re-initialized
-      randomShuffleServiceAddress = remoteShuffleServiceAddress.head
-      BlockManagerId(executorId, randomShuffleServiceAddress._1, randomShuffleServiceAddress._2)
-    } else if (externalNonK8sShuffleService) {
+    shuffleServerId = if (externalShuffleServiceEnabled) {
       logInfo(s"external shuffle service port = $externalShuffleServicePort")
       BlockManagerId(executorId, blockTransferService.hostName, externalShuffleServicePort)
     } else {
       blockManagerId
     }
 
-    if (externalk8sShuffleServiceEnabled && blockManagerId.isDriver) {
-      // Register Drivers' configuration with the k8s shuffle services
-      remoteShuffleServiceAddress.foreach { ssId =>
-        shuffleClient.asInstanceOf[KubernetesExternalShuffleClient]
-          .registerDriverWithShuffleService(
-            ssId._1, ssId._2,
-            conf.getTimeAsMs("spark.storage.blockManagerSlaveTimeoutMs",
-              s"${conf.getTimeAsSeconds("spark.network.timeout", "120s")}s"),
-            conf.get(config.EXECUTOR_HEARTBEAT_INTERVAL))
-      }
-    } else if (externalNonK8sShuffleService && !blockManagerId.isDriver) {
+    if (externalShuffleServiceEnabled && !blockManagerId.isDriver) {
       // Register Executors' configuration with the local shuffle service, if one should exist.
       registerWithExternalShuffleServer()
     }
@@ -361,9 +326,6 @@ private[spark] class BlockManager(
       }
     }
   }
-
-  private[spark] def getRandomShuffleHost: String = randomShuffleServiceAddress._1
-  private[spark] def getRandomShufflePort: Int = randomShuffleServiceAddress._2
 
   /**
    * Re-register with the master and report all blocks to it. This will be called by the heart beat
@@ -1702,7 +1664,7 @@ private[spark] object BlockManager {
     blockManagers.toMap
   }
 
-  private class ShuffleMetricsSource(
+  class ShuffleMetricsSource(
       override val sourceName: String,
       metricSet: MetricSet) extends Source {
 

--- a/core/src/test/scala/org/apache/spark/SplitFilesShuffleIO.scala
+++ b/core/src/test/scala/org/apache/spark/SplitFilesShuffleIO.scala
@@ -33,7 +33,7 @@ class SplitFilesShuffleIO(conf: SparkConf) extends ShuffleDataIO {
   override def initialize(): Unit = {}
 
   override def readSupport(): ShuffleReadSupport = (appId: String, shuffleId: Int, mapId: Int) => {
-    reduceId: Int => {
+    (reduceId: Int, shuffleLocation: Optional[ShuffleLocation]) => {
       new FileInputStream(resolvePartitionFile(appId, shuffleId, mapId, reduceId))
     }
   }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -49,7 +49,8 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
   private var taskMetrics: TaskMetrics = _
   private var tempDir: File = _
   private var outputFile: File = _
-  private val conf: SparkConf = new SparkConf(loadDefaults = false).set("spark.app.id", "spark-app-id")
+  private val conf: SparkConf =
+    new SparkConf(loadDefaults = false).set("spark.app.id", "spark-app-id")
   private val temporaryFilesCreated: mutable.Buffer[File] = new ArrayBuffer[File]()
   private val blockIdToFileMap: mutable.Map[BlockId, File] = new mutable.HashMap[BlockId, File]
   private var shuffleHandle: BypassMergeSortShuffleHandle[Int, Int] = _

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesExternalShuffleService.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesExternalShuffleService.scala
@@ -282,6 +282,7 @@ private[spark] class KubernetesExternalShuffleBlockHandler(
     allMetrics.put("openBlockRequestLatencyMillis", _openBlockRequestLatencyMillis)
     allMetrics.put("registerDriverRequestLatencyMillis", _registerDriverRequestLatencyMillis)
     allMetrics.put("blockTransferRateBytes", _blockTransferRateBytes)
+
     override def getMetrics: util.Map[String, Metric] = allMetrics
   }
 
@@ -297,10 +298,10 @@ private[spark] class KubernetesExternalShuffleService(
   extends ExternalShuffleService(conf, securityManager) {
 
   protected override def newShuffleBlockHandler(
-      conf: TransportConf): ExternalShuffleBlockHandler = {
-    val cleanerIntervals = this.conf.get(KUBERNETES_REMOTE_SHUFFLE_SERVICE_CLEANUP_INTERVAL)
-    val indexCacheSize = this.conf.get("spark.shuffle.service.index.cache.size", "100m")
-    new KubernetesExternalShuffleBlockHandler(conf, cleanerIntervals, indexCacheSize)
+      transportConf: TransportConf): ExternalShuffleBlockHandler = {
+    val cleanerIntervals = conf.get(KUBERNETES_REMOTE_SHUFFLE_SERVICE_CLEANUP_INTERVAL)
+    val indexCacheSize = conf.get("spark.shuffle.service.index.cache.size", "100m")
+    new KubernetesExternalShuffleBlockHandler(transportConf, cleanerIntervals, indexCacheSize)
   }
 }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
@@ -139,10 +139,4 @@ class KubernetesShuffleServiceAddressProvider(
 
     override def onClose(e: KubernetesClientException): Unit = {}
   }
-
-  private implicit def toRunnable(func: () => Unit): Runnable = {
-    new Runnable {
-      override def run(): Unit = func()
-    }
-  }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
@@ -92,6 +92,7 @@ class KubernetesShuffleServiceAddressProvider(
     }
   }
 
+  // TODO: Re-register with found shuffle service instances
   private def pollForPods(): Unit = {
     val writeLock = podsUpdateLock.writeLock()
     writeLock.lock()

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterManager.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterManager.scala
@@ -60,8 +60,9 @@ private[spark] class MesosClusterManager extends ExternalClusterManager {
 
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {
     scheduler.asInstanceOf[TaskSchedulerImpl].initialize(backend)
+  }
 
-  override def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider =
+  def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider = {
     DefaultShuffleServiceAddressProvider
   }
 }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterManager.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterManager.scala
@@ -54,6 +54,8 @@ private[spark] class YarnClusterManager extends ExternalClusterManager {
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {
     scheduler.asInstanceOf[TaskSchedulerImpl].initialize(backend)
   }
-  def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider =
+
+  def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider = {
     DefaultShuffleServiceAddressProvider
+  }
 }


### PR DESCRIPTION
Test with this, for example, no need for a cluster or a DFS at all:
./bin/spark-shell --master 'local-cluster[4,1,1024]' \
  --conf spark.shuffle.io.plugin.class=org.apache.spark.shuffle.dfs.DFSShuffleDataIO \
  --conf spark.shuffle.dfs.basePath=file:/tmp/dfs.io